### PR TITLE
BSP-99: Fix race condition

### DIFF
--- a/misc/test-create-lots-of-items.js
+++ b/misc/test-create-lots-of-items.js
@@ -1,0 +1,41 @@
+// very naive performance test to see how many items we can create per second.
+// feel free to run multiple instances of item-store to see how that affects the results.
+var axios = require("axios");
+var data = JSON.stringify({
+    name: "Golden Goose",
+    data: { level: "rare", type: "goose", attribute: "gold" },
+    total_quantity: 10,
+    available_quantity: 10
+});
+
+var config = {
+    method: "post",
+    url: "http://localhost:8000/item-store/item",
+    headers: {
+        "Content-Type": "application/json"
+    },
+    data: data
+};
+
+(async () => {
+    try {
+        const all = [];
+        const time = Date.now();
+        for (let i = 0; i < 1000; i++) {
+            all.push(axios(config));
+        }
+        Promise.all(all).then(() => {
+            console.log("done", Date.now() - time);
+        });
+    } catch (err) {
+        console.error(err);
+    }
+})();
+
+// latest benchmarks on AMD Ryzen 2700, 8 cores/16 threads, for 1000 item create
+// 1 instance = 18s
+// 2 instances = 12s
+// 3 instances = 10s
+// 5 instances = 8s
+// 8 instances = 6s
+// 16 instances = 4s

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
     "name": "item-store",
-    "version": "0.0.2",
+    "version": "0.0.6",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
-            "version": "0.0.2",
+            "version": "0.0.6",
             "license": "Apache-2.0",
             "dependencies": {
                 "@elastic/elasticsearch": "^7.11.0",
@@ -17,6 +17,7 @@
                 "@types/elasticsearch": "^5.0.37",
                 "@typescript-eslint/eslint-plugin": "^4.15.0",
                 "@typescript-eslint/parser": "^4.15.0",
+                "axios": "^0.21.1",
                 "concurrently": "^5.3.0",
                 "eslint": "^7.20.0",
                 "eslint-config-prettier": "^7.2.0",
@@ -880,6 +881,7 @@
                 "jest-resolve": "^26.6.2",
                 "jest-util": "^26.6.2",
                 "jest-worker": "^26.6.2",
+                "node-notifier": "^8.0.0",
                 "slash": "^3.0.0",
                 "source-map": "^0.6.0",
                 "string-length": "^4.0.1",
@@ -1824,6 +1826,15 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
+        "node_modules/axios": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "dev": true,
+            "dependencies": {
+                "follow-redirects": "^1.10.0"
+            }
+        },
         "node_modules/babel-jest": {
             "version": "26.6.3",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -2370,6 +2381,7 @@
             "dependencies": {
                 "anymatch": "~3.1.1",
                 "braces": "~3.0.2",
+                "fsevents": "~2.3.1",
                 "glob-parent": "~5.1.0",
                 "is-binary-path": "~2.1.0",
                 "is-glob": "~4.0.1",
@@ -3832,6 +3844,26 @@
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
             "dev": true
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/for-in": {
             "version": "1.0.2",
@@ -5338,6 +5370,7 @@
                 "@types/node": "*",
                 "anymatch": "^3.0.3",
                 "fb-watchman": "^2.0.0",
+                "fsevents": "^2.1.2",
                 "graceful-fs": "^4.2.4",
                 "jest-regex-util": "^26.0.0",
                 "jest-serializer": "^26.6.2",
@@ -11715,6 +11748,15 @@
             "integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==",
             "dev": true
         },
+        "axios": {
+            "version": "0.21.1",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.1.tgz",
+            "integrity": "sha512-dKQiRHxGD9PPRIUNIWvZhPTPpl1rf/OxTYKsqKUDjBwYylTvV7SjSHJb9ratfyzM6wCdLCOYLzs73qpg5c4iGA==",
+            "dev": true,
+            "requires": {
+                "follow-redirects": "^1.10.0"
+            }
+        },
         "babel-jest": {
             "version": "26.6.3",
             "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-26.6.3.tgz",
@@ -13345,6 +13387,12 @@
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.1.1.tgz",
             "integrity": "sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==",
+            "dev": true
+        },
+        "follow-redirects": {
+            "version": "1.14.1",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
+            "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
             "dev": true
         },
         "for-in": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "item-store",
     "private": true,
-    "version": "0.0.5",
+    "version": "0.0.6",
     "description": "Store and retrieve items from elasticsearch",
     "main": "dist/index.js",
     "scripts": {
@@ -42,6 +42,7 @@
         "@types/elasticsearch": "^5.0.37",
         "@typescript-eslint/eslint-plugin": "^4.15.0",
         "@typescript-eslint/parser": "^4.15.0",
+        "axios": "^0.21.1",
         "concurrently": "^5.3.0",
         "eslint": "^7.20.0",
         "eslint-config-prettier": "^7.2.0",

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,7 +2,10 @@ const {
     SERVICE_NAME = "item-store",
     NATS_URL = "",
     ELASTICSEARCH_URI = "",
-    ELASTICSEARCH_INDEX_NAME = ""
+    ELASTICSEARCH_INDEX_NAME = "",
+    // should be ajusted according to the number of processes.
+    // 4 instances of item-store = 4 potential concurrent requests = 4 retries
+    RETRY_ON_CONFLICT_RETRIES = 4
 } = process.env;
 
 if (!NATS_URL) {
@@ -23,7 +26,15 @@ if (!ELASTICSEARCH_INDEX_NAME) {
     );
 }
 
-export { SERVICE_NAME, ELASTICSEARCH_URI, NATS_URL };
+const NUM_RETRY_ON_CONFLICT_RETRIES = Number(RETRY_ON_CONFLICT_RETRIES);
+
+export {
+    SERVICE_NAME,
+    ELASTICSEARCH_URI,
+    NATS_URL,
+    NUM_RETRY_ON_CONFLICT_RETRIES as RETRY_ON_CONFLICT_RETRIES
+};
+
 export const INDEXES = {
     INVENTORY: `${ELASTICSEARCH_INDEX_NAME}-inventory`,
     WAREHOUSE: `${ELASTICSEARCH_INDEX_NAME}-warehouse`,

--- a/src/services/nats.ts
+++ b/src/services/nats.ts
@@ -55,10 +55,10 @@ export function registerPrivateHandlers(
     prefix: string,
     handlers: PrivateNatsHandler[]
 ): void {
-    handlers.map(([subject, handler]) => {
+    handlers.map(([subject, handler, options]) => {
         const fullSubject = `${prefix}.${subject}`;
         console.log(`[ITEM-STORE] Registering private handler ${fullSubject}`);
-        handler(natsConnection.subscribe(fullSubject));
+        handler(natsConnection.subscribe(fullSubject, options));
     });
 }
 
@@ -66,10 +66,10 @@ export function registerPublicHandlers(
     prefix: string,
     handlers: PublicNatsHandler[]
 ): void {
-    handlers.map(([method, subject, handler]) => {
+    handlers.map(([method, subject, handler, options]) => {
         const fullSubject = `${method}:${prefix}.${subject}`;
         console.log(`[ITEM-STORE] Registering public handler ${fullSubject}`);
-        handler(natsConnection.subscribe(fullSubject));
+        handler(natsConnection.subscribe(fullSubject, options));
     });
 }
 

--- a/src/services/warehouseItemStore.ts
+++ b/src/services/warehouseItemStore.ts
@@ -1,7 +1,7 @@
 import { getClient } from "./elasticSearch";
 import { JSONWarehouseItem } from "../item";
 import { INDEXES } from "../config";
-import { getAdminDocField, setAdminDocField } from "./adminStore";
+import { incrementLastWarehouseItemId } from "./adminStore";
 import { SearchResponse } from "elasticsearch";
 
 interface WarehouseItemsSearchResults {
@@ -14,8 +14,7 @@ export async function addWarehouseItem(
 ): Promise<number> {
     const client = getClient();
 
-    const lastId = await getAdminDocField<number>("last_warehouse_item_id");
-    const newId = lastId + 1;
+    const newId = await incrementLastWarehouseItemId();
 
     await client.index({
         index: INDEXES.WAREHOUSE,
@@ -25,8 +24,6 @@ export async function addWarehouseItem(
             item_id: newId
         }
     });
-
-    await setAdminDocField<number>("last_warehouse_item_id", newId);
 
     return newId;
 }


### PR DESCRIPTION
- When multiple services try to bump to last warehouse item id
simultaneously they may try to update the same version of the admin
document which creates a conflict. Fixing by using the
retries_on_conflict option with a number of retries configurable via env
variable